### PR TITLE
Add (artifact) build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: build
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Build
+        run: cargo build --locked --release --target x86_64-unknown-linux-gnu
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: game-linux-x86_64
+          path: ./target/x86_64-unknown-linux-gnu/release/game
+          if-no-files-found: error


### PR DESCRIPTION
Adds a pipeline to build and upload the binary when something is pushed to `main`. Only contains a Linux x86 binary atm, building static Windows binaries correctly isn't as trivial as Linux ones.